### PR TITLE
Changed link override to active project

### DIFF
--- a/MaybeJump/MaybeJump.cs
+++ b/MaybeJump/MaybeJump.cs
@@ -15,7 +15,7 @@ namespace MaybeJump
         private static ModConfigurationKey<bool> EnableRight = new ModConfigurationKey<bool>("EnableRight", "Enable right jump.", () => true);
 
         public override string Author => "Banane9";
-        public override string Link => "https://github.com/Banane9/NeosMaybeJump";
+        public override string Link => "https://github.com/Ryn-Fox/ResoniteMaybeJump/";
         public override string Name => "MaybeJump";
         public override string Version => "1.1.0";
 


### PR DESCRIPTION
So it can be updated by [ResoniteModUpdater CLI](https://github.com/hazre/ResoniteModUpdater) without reverting to the outdated mod

- Workaround until original mod gets updated